### PR TITLE
Config for NS build

### DIFF
--- a/keycaster.el
+++ b/keycaster.el
@@ -64,7 +64,8 @@
   :type 'integer
   :group 'keycaster)
 
-(defcustom keycaster-use-child-frame (eq system-type 'windows-nt)
+(defcustom keycaster-use-child-frame (or (eq system-type 'windows-nt)
+                                         (eq window-system 'ns))
   "Whether to display keystrokes in child-frame.
 
 Note: The child-frame is broken in GTK3 version.


### PR DESCRIPTION
I have checked the default configuration in NS build and EMP build.
And I found we can only use `fit-frame-to-buffer` to show input keys.

However, in that case, we have to specify `keycaster-use-child-frame` as `t` for NS build.
When I use `nil` for NS build, then an error related to `keycaster-pre-commend` is reported.

```
|                           | NS  | NS  | EMP | EMP |
|---------------------------+-----+-----+-----+-----|
| fit-frame-to-buffer       | YES | YES | YES | YES |
| keycaster-use-child-frame | nil | t   | nil | t   |
|---------------------------+-----+-----+-----+-----|
|                           | NG  | OK! | OK! | OK! |
```

NS build: Emacs 27.0.60, 26.3.50
EMP build: Emacs 26.3